### PR TITLE
Add interrupt blocks

### DIFF
--- a/lang/ca-ES.js
+++ b/lang/ca-ES.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Botó',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Graus (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa',
         LANG_SERVO_MOVE_TOOLTIP: 'Moure el servo entre 0 i 180 graus.',
-        LANG_SERVO_WARNING: 'It is not possible to set the servo pin using a variable'
+        LANG_SERVO_WARNING: 'It is not possible to set the servo pin using a variable',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/en-GB.js
+++ b/lang/en-GB.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',
         LANG_VARIABLES_TYPE_STRING: 'String',
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Button',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Degrees (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Delay [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Move between 0~180 degree',
-        LANG_SERVO_WARNING:'It is not possible to set the servo pin using a variable'
+        LANG_SERVO_WARNING:'It is not possible to set the servo pin using a variable',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/es-ES.js
+++ b/lang/es-ES.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Entero',
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Entero largo',
         LANG_VARIABLES_TYPE_STRING: 'Texto',
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declarar variable VOLATIL GLOBAL ',
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'de tipo ',
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: '=',
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declara y define una variable VOLATIL GLOBAL de tipo entero (int) o texto (String) usada en funciones de manejo de interrupciones.',
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Botón',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Grados (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Mover el servo entre 0 y 180 grados.',
-        LANG_SERVO_WARNING:'No puedes asignar una variable al pin del servo'
+        LANG_SERVO_WARNING:'No puedes asignar una variable al pin del servo',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupciones',
+        LANG_INTERRUPTS_STATE: 'Establece estado de las interrupciones a ',
+        LANG_INTERRUPTS_STATE_ENABLED: 'HABILITADO',
+        LANG_INTERRUPTS_STATE_DISABLED: 'DESHABILITADO',
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Habilita o deshabilita las interrupciones. Algunas funciones no podrán usarse mientras que las interrupciones estén deshabilitadas. Utilizar solo para secciones críticas del programa.',
+        LANG_INTERRUPTS_ATTACH: 'Asociar la función ',
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'en el modo ',
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'con la interrupción del pin digital',
+        LANG_INTERRUPTS_ATTACH_LOW: 'BAJO',
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CAMBIO',
+        LANG_INTERRUPTS_ATTACH_RISING: 'SUBIENDO',
+        LANG_INTERRUPTS_ATTACH_FALLING: 'BAJANDO',
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_sin_retorno',
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Especifica la función que se va a ejecutar cuando se produzca la interrupción en el pin especificado.',
+        LANG_INTERRUPTS_DETACH: 'Desasociar la interrupción del pin digital',
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Desactiva la asociación de la interrupción especificada en el pin. Cuando se active ese pin, ya no se ejecutará la función asociada.'
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/eu-ES.js
+++ b/lang/eu-ES.js
@@ -355,6 +355,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer', // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer', // To translate
         LANG_VARIABLES_TYPE_STRING: 'String', // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'zum blokeak',
         LANG_ZUM_BUTTON: 'Botoia',
@@ -412,7 +416,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Graduak (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Etena [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Serboa 0 eta 180 gradu artean biratu.',
-        LANG_SERVO_WARNING: 'Serboaren pinari ezin diozu aldagai bat esleitu'
+        LANG_SERVO_WARNING: 'Serboaren pinari ezin diozu aldagai bat esleitu',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Bouton',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Degrés (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Attendre [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Bouger le servo entre 0 et 180 degrés',
-        LANG_SERVO_WARNING: 'Il n’est pas possible de déterminer la broche du servo à l’aide d’une variable'
+        LANG_SERVO_WARNING: 'Il n’est pas possible de déterminer la broche du servo à l’aide d’une variable',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/gl-ES.js
+++ b/lang/gl-ES.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'enteiro',
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'enteiro longo',
         LANG_VARIABLES_TYPE_STRING: 'Texto',
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Botón',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Graos (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Mover o servo entre 0 e 180 grados.',
-        LANG_SERVO_WARNING:'Non é posible definir o pin do servo utilizando unha variable'
+        LANG_SERVO_WARNING:'Non é posible definir o pin do servo utilizando unha variable',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/it_IT.js
+++ b/lang/it_IT.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Pulsante',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Gradi (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa',
         LANG_SERVO_MOVE_TOOLTIP: 'Sposta di 0~180 gradi',
-        LANG_SERVO_WARNING: 'Impossibile impostare il pin del servo motore utilizzando una variabile'
+        LANG_SERVO_WARNING: 'Impossibile impostare il pin del servo motore utilizzando una variabile',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/pl-PL.js
+++ b/lang/pl-PL.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Liczba całkowita',
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Długa liczba całkowita',
         LANG_VARIABLES_TYPE_STRING: 'Ciąg znaków',
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //bloki Zum:
         LANG_CATEGORY_ZUM: 'Bloki Zum',
         LANG_ZUM_BUTTON: 'Przycisk',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Stopnie (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Opóźnienie [ms]',
         LANG_SERVO_MOVE_TOOLTIP: 'Serwomechanizm obrotu w zakresie 0~180 stopni.',
-        LANG_SERVO_WARNING:'Ustawianie pinu serwomechanizmu przy użyciu zmiennej nie jest możliwe.'
+        LANG_SERVO_WARNING:'Ustawianie pinu serwomechanizmu przy użyciu zmiennej nie jest możliwe.',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/pt-BR.js
+++ b/lang/pt-BR.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Botão',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Graus (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa',
         LANG_SERVO_MOVE_TOOLTIP: 'Mover o servo entre 0 e 180 graus.',
-        LANG_SERVO_WARNING: 'Não é possível definir o pin servo utilizando uma variável.'
+        LANG_SERVO_WARNING: 'Não é possível definir o pin servo utilizando uma variável.',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/pt-PT.js
+++ b/lang/pt-PT.js
@@ -358,6 +358,10 @@
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         //zum blocks :
         LANG_CATEGORY_ZUM: 'Zum bloqs',
         LANG_ZUM_BUTTON: 'Botão',
@@ -415,7 +419,24 @@
         LANG_SERVO_MOVE_DEGREES: 'Graus (0~180)',
         LANG_SERVO_MOVE_DELAY: 'Pausa',
         LANG_SERVO_MOVE_TOOLTIP: 'Mover o servo entre 0 e 180 graus.',
-        LANG_SERVO_WARNING: 'Não é possível definir o pin servo utilizando uma variável.'
+        LANG_SERVO_WARNING: 'Não é possível definir o pin servo utilizando uma variável.',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
     };
     // Node
     if (typeof module !== 'undefined' && module.exports) {

--- a/lang/ru.js
+++ b/lang/ru.js
@@ -358,6 +358,10 @@ LANG_CONTROLS_BASE_MILLIS_TOOLTIP: 'Number of milliseconds since the program sta
         LANG_VARIABLES_TYPE_INTEGER: 'Integer',  // To translate
         LANG_VARIABLES_TYPE_INTEGER_LONG: 'Long Integer',  // To translate
         LANG_VARIABLES_TYPE_STRING: 'String',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL: 'Declare VOLATILE GLOBAL variable ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TYPE: 'of type ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS: 'equals ',  // To translate
+        LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP: 'Declares and defines a VOLATILE GLOBAL variable of type int or String used in a ISR function.',  // To translate
         // Zum блоки:
         LANG_CATEGORY_ZUM: 'Блоки Zum',
         LANG_ZUM_BUTTON: 'Кнопка',
@@ -415,7 +419,25 @@ LANG_CONTROLS_BASE_MILLIS_TOOLTIP: 'Number of milliseconds since the program sta
         LANG_SERVO_MOVE_DEGREES: '° (0 ~ 180)',
         LANG_SERVO_MOVE_DELAY: 'Пауза',
         LANG_SERVO_MOVE_TOOLTIP: 'Повернуть вал сервопривода между 0 и 180 градусов.',
-        LANG_SERVO_WARNING: 'Вы не можете установить управляющий PIN сервопривода с помощью переменной.'    };
+        LANG_SERVO_WARNING: 'Вы не можете установить управляющий PIN сервопривода с помощью переменной.',
+        //interrupt blocks :
+        LANG_CATEGORY_INTERRUPTS: 'Interrupts',  // To translate
+        LANG_INTERRUPTS_STATE: 'Set interrupts state to ',  // To translate
+        LANG_INTERRUPTS_STATE_ENABLED: 'ENABLED',  // To translate
+        LANG_INTERRUPTS_STATE_DISABLED: 'DISABLED',  // To translate
+        LANG_INTERRUPTS_STATE_TOOLTIP: 'Enable or Disable interrupts. Some functions will not work while interrupts are disabled. Use only for particularly critical sections of code.',  // To translate
+        LANG_INTERRUPTS_ATTACH: 'Attach procedure ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM2: 'in mode ',  // To translate
+        LANG_INTERRUPTS_ATTACH_PARAM3: 'with interrupt of digital pin',  // To translate
+        LANG_INTERRUPTS_ATTACH_LOW: 'LOW',  // To translate
+        LANG_INTERRUPTS_ATTACH_CHANGE: 'CHANGE',  // To translate
+        LANG_INTERRUPTS_ATTACH_RISING: 'RISING',  // To translate
+        LANG_INTERRUPTS_ATTACH_FALLING: 'FALLING',  // To translate
+        LANG_INTERRUPTS_ATTACH_PROCEDURE: 'func_without_return',  // To translate
+        LANG_INTERRUPTS_ATTACH_TOOLTIP: 'Set the procedure to be executed when an interrupt is raised in the specified pin.',  // To translate
+        LANG_INTERRUPTS_DETACH: 'Detach interrupt on digital pin',  // To translate
+        LANG_INTERRUPTS_DETACH_TOOLTIP: 'Disables the interrupt on the pin. When the pin is activated, the procedure associated is no longer executed.'  // To translate
+    };
     // Node
     if (typeof module !== 'undefined' && module.exports) {
         module.exports = language;

--- a/src/blocks/interrupt_attach/README.md
+++ b/src/blocks/interrupt_attach/README.md
@@ -1,0 +1,13 @@
+interrupt_attach
+===========
+
+Associates a interrupt pin with a function (with no parameters and no return value).
+
+Parameters
+----------
+
+| Param name | Description | Type     |
+ ------------|-------------|----------
+| pin     | Pin associated with the interrupt | `Number` |
+| function     | Dropdown used to select which function (no return) is associated | `Dropdown` |
+| mode     | Dropdown to select mode (LOW, CHANGE, RISING or FALLING) | `Dropdown` |

--- a/src/blocks/interrupt_attach/interrupt_attach.c.tpl
+++ b/src/blocks/interrupt_attach/interrupt_attach.c.tpl
@@ -1,0 +1,1 @@
+attachInterrupt(digitalPinToInterrupt({{block_pin}}),{{funcName}},{{mode}});

--- a/src/blocks/interrupt_attach/interrupt_attach.js
+++ b/src/blocks/interrupt_attach/interrupt_attach.js
@@ -1,0 +1,183 @@
+'use strict';
+/* global Blockly, JST, RoboBlocks */
+/**
+ * interrupt_attach code generation
+ * @return {String} Code generated with block parameters
+ */
+Blockly.Arduino.interrupt_attach = function() {
+    var dropdown_pin = Blockly.Arduino.valueToCode(this, 'PIN', Blockly.Arduino.ORDER_ATOMIC);
+    var funcName = this.getFieldValue('PROCEDURES');
+    var dropdown_mode = this.getFieldValue('MODE');
+    var code = '';
+    var a = RoboBlocks.findPinMode(dropdown_pin);
+    dropdown_pin = a['pin'];
+    if (RoboBlocks.isVariable(dropdown_pin)) {
+        code += JST['interrupt_attach']({
+            'block_pin': dropdown_pin,
+            'funcName': funcName,
+            'mode': dropdown_mode
+        });
+    } else {
+        code += JST['interrupt_attach']({
+            'block_pin': dropdown_pin,
+            'funcName': funcName,
+            'mode': dropdown_mode
+        });
+    }
+    return code;
+};
+Blockly.Blocks.interrupt_attach = {
+    // Variable getter.
+    category: RoboBlocks.locales.getKey('LANG_CATEGORY_INTERRUPTS'), // Variables are handled specially.
+    helpUrl: RoboBlocks.URL_INTERRUPTS,
+    init: function() {
+        this.setColour(RoboBlocks.LANG_COLOUR_INTERRUPTS);
+        this.appendDummyInput('DUMMY')
+                .appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH'))
+                .appendField(new Blockly.FieldDropdown(this.getProcedures()), 'PROCEDURES')
+                .appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_PARAM2'))
+                .appendField(new Blockly.FieldDropdown([
+            [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_LOW')||'LOW' , 'LOW'],
+            [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_CHANGE')||'CHANGE' , 'CHANGE'],
+            [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_RISING')||'RISING' , 'RISING'],
+            [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_FALLING')||'FALLING' , 'FALLING']
+        ]), 'MODE');
+        this.appendValueInput('PIN').appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_PARAM3')).appendField(RoboBlocks.locales.getKey('LANG_ADVANCED_INOUT_DIGITAL_WRITE_PIN'));
+        this.setPreviousStatement(true);
+        this.setNextStatement(true);
+        this.setTooltip(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_TOOLTIP'));
+        this.quarkConnections_ = null;
+        this.quarkArguments_ = null;
+    },
+    validName: function(name) {
+        if (name && name.length > 0) {
+            var i = 0;
+            while (i < name.length) {
+                if (!isNaN(parseFloat(name[i]))) {
+                    name = name.substring(1, name.length);
+                } else {
+                    break;
+                }
+            }
+            name = name.replace(/([ ])/g, '_');
+            name = name.replace(/([áàâä])/g, 'a');
+            name = name.replace(/([éèêë])/g, 'e');
+            name = name.replace(/([íìîï])/g, 'i');
+            name = name.replace(/([óòôö])/g, 'o');
+            name = name.replace(/([úùûü])/g, 'u');
+            name = name.replace(/([ñ])/g, 'n');
+            name = name.replace(/([\/\,\!\\\^\$\{\}\[\]\(\)\.\*\+\?\|<>\-\&\Ç\%\=\~\{\}\¿\¡\"\@\:\;\-\"\·\|\º\ª\¨\'\·\̣\─\ç\`\´\¨\^])/g, '');
+            i = 0;
+            while (i < name.length) {
+                if (!isNaN(parseFloat(name[i]))) {
+                    name = name.substring(1, name.length);
+                } else {
+                    break;
+                }
+            }
+        }
+        return name;
+    },
+    getProcedures: function() {
+        var procedures = Blockly.Procedures.allProcedures();
+        var procedures_dropdown = [];
+        if (procedures[0].length > 0) {
+            for (var i in procedures[0]) {
+                var proc_name = procedures[0][i][0];
+                proc_name = this.validName(proc_name);
+                procedures_dropdown.push([proc_name, proc_name]);
+            }
+        } else {
+            procedures_dropdown.push([RoboBlocks.locales.getKey('LANG_PROCEDURES_DEFNORETURN_PROCEDURE'), RoboBlocks.locales.getKey('LANG_PROCEDURES_DEFNORETURN_PROCEDURE')]);
+        }
+        return procedures_dropdown;
+    },
+    exists: function() {
+        var procedures = Blockly.Procedures.allProcedures();
+        if (procedures[0].length > 0) {
+            for (var i in procedures[0]) {
+                if (procedures[0][i][0] === this.getFieldValue('PROCEDURES')) {
+                    return true;
+                }
+            }
+        } else {
+            return false;
+        }
+    },
+    onchange: function() {
+        if (!this.workspace) {
+            // Block has been deleted.
+            return;
+        }
+        if (this.getFieldValue('PROCEDURES') !== this.last_procedure && this.getFieldValue('PROCEDURES')) {
+            //this.changeVariables();
+            this.last_procedure = this.getFieldValue('PROCEDURES');
+        }
+        if (!this.exists()) {
+            try {
+                this.setWarningText(RoboBlocks.locales.getKey('LANG_PROCEDURES_CALL_WITHOUT_DEFINITION'));
+            } catch (e) {}
+        } else {
+            try {
+                this.setWarningText(null);
+            } catch (e) {}
+        }
+    },
+    renameProcedure: function(oldName, newName) {
+        if (this.last_procedure) {
+            var procedures = this.getProcedures();
+            for (var i in procedures) {
+                if (Blockly.Names.equals(oldName, procedures[i][0])) {
+                    this.removeInput('DUMMY');
+                    //this.removeInput('PIN');
+                    //this.appendDummyInput('DUMMY').appendField(new Blockly.FieldDropdown(this.getProcedures()), 'PROCEDURES');
+                    this.appendDummyInput('DUMMY')
+                        .appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH'))
+                        .appendField(new Blockly.FieldDropdown(this.getProcedures()), 'PROCEDURES')
+                        .appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_PARAM2'))
+                        .appendField(new Blockly.FieldDropdown([
+                        [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_LOW')||'LOW' , 'LOW'],
+                        [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_CHANGE')||'CHANGE' , 'CHANGE'],
+                        [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_RISING')||'RISING' , 'RISING'],
+                        [RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_FALLING')||'FALLING' , 'FALLING']
+                    ]), 'MODE');
+                    //this.appendValueInput('PIN').appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_ATTACH_PARAM3')).appendField(RoboBlocks.locales.getKey('LANG_ADVANCED_INOUT_DIGITAL_WRITE_PIN'));
+                    this.moveInputBefore('DUMMY','PIN');
+                }
+            }
+            if (this.last_procedure === oldName) {
+                this.last_procedure = newName;
+            }
+            try {
+                this.setFieldValue(this.last_procedure, 'PROCEDURES');
+            } catch (e) {}
+        }
+    },
+    mutationToDom: function() {
+        // Save the name and arguments (none of which are editable).
+        var container = document.createElement('mutation');
+        container.setAttribute('name', this.getFieldValue('PROCEDURES'));
+        if (typeof this.arguments_ === 'undefined') {
+            //this.arguments_ = this.getVariables(this.getFieldValue('PROCEDURES'));
+        }
+        if (typeof this.arguments_ === 'undefined') {
+            this.arguments_ = [];
+        }
+        for (var x = 0; x < this.arguments_.length; x++) {
+            var parameter = document.createElement('arg');
+            parameter.setAttribute('name', this.arguments_[x]);
+            container.appendChild(parameter);
+        }
+        return container;
+    },
+    domToMutation: function(xmlElement) {
+        this.xmlElement = xmlElement;
+        // Restore the name and parameters.
+        var name = xmlElement.getAttribute('name');
+        this.last_procedure = name;
+        this.setFieldValue(name, 'PROCEDURES');
+        for (var x = 0; x < xmlElement.childNodes.length; x++) {
+            this.appendValueInput('ARG' + x).appendField(xmlElement.childNodes[x].getAttribute('name'), 'ARG_NAME' + x).setAlign(Blockly.ALIGN_RIGHT);
+        }
+    }
+};

--- a/src/blocks/interrupt_detach/README.md
+++ b/src/blocks/interrupt_detach/README.md
@@ -1,0 +1,11 @@
+interrupt_detach
+===========
+
+Disassociates a interrupt pin with a function.
+
+Parameters
+----------
+
+| Param name | Description | Type     |
+ ------------|-------------|----------
+| pin     | Pin associated with the interrupt | `Number` |

--- a/src/blocks/interrupt_detach/interrupt_detach.c.tpl
+++ b/src/blocks/interrupt_detach/interrupt_detach.c.tpl
@@ -1,0 +1,1 @@
+detachInterrupt(digitalPinToInterrupt({{block_pin}}));

--- a/src/blocks/interrupt_detach/interrupt_detach.js
+++ b/src/blocks/interrupt_detach/interrupt_detach.js
@@ -1,0 +1,36 @@
+'use strict';
+/* global Blockly, JST, RoboBlocks */
+/**
+ * interrupt_detach code generation
+ * @return {String} Code generated with block parameters
+ */
+Blockly.Arduino.interrupt_detach = function() {
+    var dropdown_pin = Blockly.Arduino.valueToCode(this, 'PIN', Blockly.Arduino.ORDER_ATOMIC);
+    var code = '';
+    var a = RoboBlocks.findPinMode(dropdown_pin);
+    dropdown_pin = a['pin'];
+    if (RoboBlocks.isVariable(dropdown_pin)) {
+        code += JST['interrupt_detach']({
+            'block_pin': dropdown_pin
+        });
+    } else {
+        code += JST['interrupt_detach']({
+            'block_pin': dropdown_pin
+        });
+    }
+    return code;
+};
+Blockly.Blocks.interrupt_detach = {
+    // Variable getter.
+    category: RoboBlocks.locales.getKey('LANG_CATEGORY_INTERRUPTS'), // Variables are handled specially.
+    helpUrl: RoboBlocks.URL_INTERRUPTS,
+    init: function() {
+        this.setColour(RoboBlocks.LANG_COLOUR_INTERRUPTS);
+        this.appendValueInput('PIN').appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_DETACH')).appendField(RoboBlocks.locales.getKey('LANG_ADVANCED_INOUT_DIGITAL_WRITE_PIN'));
+        this.setPreviousStatement(true);
+        this.setNextStatement(true);
+        this.setTooltip(RoboBlocks.locales.getKey('LANG_INTERRUPTS_DETACH_TOOLTIP'));
+        this.quarkConnections_ = null;
+        this.quarkArguments_ = null;
+    }
+};

--- a/src/blocks/interrupt_state/README.md
+++ b/src/blocks/interrupt_state/README.md
@@ -1,0 +1,11 @@
+interrupt_state
+==========
+
+Enables o disables interrupts. Interrupts allow certain important tasks to happen in the background and are enabled by default. Some functions will not work while interrupts are disabled. Disable interrupts only for particularly critical sections of code.
+
+Parameters
+----------
+
+| Param name | Description | Type     |
+ ------------|-------------|----------
+| state     | Dropdown to select the ON of OFF state | `Dropdown` |

--- a/src/blocks/interrupt_state/interrupt_state.js
+++ b/src/blocks/interrupt_state/interrupt_state.js
@@ -1,0 +1,45 @@
+'use strict';
+/* global Blockly, JST, RoboBlocks */
+/* jshint sub:true */
+
+/**
+ * interrupt_state code generation
+ * @return {String} Code generated with block parameters
+ */
+
+Blockly.Arduino.interrupt_state = function() {
+	var dropdown_stat = this.getFieldValue('STAT');
+	var code = '';
+
+	if (dropdown_stat==='ENABLED') {
+		code = JST['interrupt_state_enabled']({});
+	} else {
+		code = JST['interrupt_state_disabled']({});
+	}
+
+	return code;
+};
+
+/**
+ * interrupt_state block definition
+ * @type {Object}
+ */
+Blockly.Blocks.interrupt_state = {
+	category: RoboBlocks.locales.getKey('LANG_CATEGORY_INTERRUPTS'),
+	helpUrl: RoboBlocks.URL_INTERRUPTS,
+	 /**
+	  * inout_builtin_led initialization
+	  */
+	init: function() {
+		this.setColour(RoboBlocks.LANG_COLOUR_INTERRUPTS);
+		this.appendDummyInput('')
+			.appendField(RoboBlocks.locales.getKey('LANG_INTERRUPTS_STATE'))
+			.appendField(new Blockly.FieldDropdown([
+				[RoboBlocks.locales.getKey('LANG_INTERRUPTS_STATE_ENABLED')||'ENABLED' , 'ENABLED'],
+				[RoboBlocks.locales.getKey('LANG_INTERRUPTS_STATE_DISABLED')||'DIABLED' , 'DISABLED']
+			]), 'STAT');
+		this.setPreviousStatement(true, null);
+		this.setNextStatement(true, null);
+		this.setTooltip(RoboBlocks.locales.getKey('LANG_INTERRUPTS_STATE_TOOLTIP'));
+	}
+};

--- a/src/blocks/interrupt_state/interrupt_state_disabled.c.tpl
+++ b/src/blocks/interrupt_state/interrupt_state_disabled.c.tpl
@@ -1,0 +1,1 @@
+noInterrupts();

--- a/src/blocks/interrupt_state/interrupt_state_enabled.c.tpl
+++ b/src/blocks/interrupt_state/interrupt_state_enabled.c.tpl
@@ -1,0 +1,1 @@
+interrupts();

--- a/src/blocks/variables_volatile_global_type/README.md
+++ b/src/blocks/variables_volatile_global_type/README.md
@@ -1,0 +1,13 @@
+variables_global_type
+===========
+
+Declares and defines a VOLATILE GLOBAL variable of type. The values of this kind of variables can be changed within a interrupt service routine function.
+
+Parameters
+----------
+
+| Param name | Description | Type     |
+ ------------|-------------|----------
+| var_name     | Name of the new variable | `String` |
+| var_type     | Type of the new variable | `String` |
+| var_value     | Value of the variable | `String`/`Number` |

--- a/src/blocks/variables_volatile_global_type/variables_volatile_global_type.js
+++ b/src/blocks/variables_volatile_global_type/variables_volatile_global_type.js
@@ -1,0 +1,120 @@
+'use strict';
+/* global Blockly,  RoboBlocks */
+/* jshint sub:true */
+/**
+ * variables_volatile_global_type code generation
+ * @return {String} Code generated with block parameters
+ */
+Blockly.Arduino.variables_volatile_global_type = function() {
+    // Variable setter.
+    var varType = this.getFieldValue('VAR_TYPE');
+    var varValue = Blockly.Arduino.valueToCode(this, 'VALUE', Blockly.Arduino.ORDER_ASSIGNMENT);
+    var varName = this.getFieldValue('VAR') || '';
+    //var isFunction = false;
+
+    //var varName = this.getFieldValue('VAR') || '';
+    var code ='';
+
+    var a=RoboBlocks.findPinMode(varValue);
+    code+=a['code'];
+    varValue=a['pin'];
+
+    Blockly.Arduino.definitions_['declare_var' + varName] = 'volatile ' + varType + ' ' + varName + ';\n';
+    Blockly.Arduino.setups_['define_var' + varName] = varName + '=' + varValue + ';\n';
+
+    RoboBlocks.variables[varName] = [varType, 'global'];
+    RoboBlocks.variables['analogRead('+varName+')'] = [varType, 'global'];
+    RoboBlocks.variables['digitalRead('+varName+')'] = [varType, 'global'];
+
+    return '';
+};
+
+Blockly.Blocks.variables_volatile_global_type = {
+    // Variable setter.
+    category: RoboBlocks.locales.getKey('LANG_CATEGORY_VARIABLES'), // Variables are handled specially.
+    helpUrl: RoboBlocks.URL_VAR,
+    init: function() {
+        this.setColour(RoboBlocks.LANG_COLOUR_VARIABLES);
+        this.appendValueInput('VALUE').
+            appendField(RoboBlocks.locales.getKey('LANG_VARIABLES_VOLATILE_GLOBAL')).
+            appendField(new Blockly.FieldTextInput(''), 'VAR').
+            appendField(RoboBlocks.locales.getKey('LANG_VARIABLES_VOLATILE_GLOBAL_TYPE')).
+            appendField(new Blockly.FieldDropdown([
+                [RoboBlocks.locales.getKey('LANG_VARIABLES_TYPE_STRING'), 'String'],
+                [RoboBlocks.locales.getKey('LANG_VARIABLES_TYPE_INTEGER'), 'int'],
+                [RoboBlocks.locales.getKey('LANG_VARIABLES_TYPE_INTEGER_LONG'), 'long'],
+                [RoboBlocks.locales.getKey('LANG_VARIABLES_TYPE_BYTE'), 'byte'],
+                [RoboBlocks.locales.getKey('LANG_VARIABLES_TYPE_FLOAT'), 'float']
+            ]), 'VAR_TYPE').
+            appendField(RoboBlocks.locales.getKey('LANG_VARIABLES_VOLATILE_GLOBAL_EQUALS'));
+        this.setInputsInline(false);
+        //this.setPreviousStatement(true);
+        //this.setNextStatement(true);
+        this.setTooltip(RoboBlocks.locales.getKey('LANG_VARIABLES_VOLATILE_GLOBAL_TOOLTIP'));
+    },
+    getVars: function() {
+        return [this.getFieldValue('VAR')];
+    },
+    renameVar: function(oldName, newName) {
+        if (Blockly.Names.equals(oldName, this.getFieldValue('VAR'))) {
+            this.setFieldValue(newName, 'VAR');
+        }
+    },
+    isVariable: function(varValue) {
+        for (var i in Blockly.Variables.allVariables()) {
+            if (Blockly.Variables.allVariables()[i] === varValue) {
+                return true;
+            }
+        }
+        return false;
+    },
+    validName: function(name) {
+        if (name && name.length > 0) {
+            var i = 0;
+            while (i < name.length) {
+                if (!isNaN(parseFloat(name[i]))) {
+                    name = name.substring(1, name.length);
+                } else {
+                    break;
+                }
+            }
+            name = name.replace(/([ ])/g, '_');
+            name = name.replace(/([áàâä])/g, 'a');
+            name = name.replace(/([éèêë])/g, 'e');
+            name = name.replace(/([íìîï])/g, 'i');
+            name = name.replace(/([óòôö])/g, 'o');
+            name = name.replace(/([úùûü])/g, 'u');
+            name = name.replace(/([ñ])/g, 'n');
+            name = name.replace(/([\/\,\!\\\^\$\{\}\[\]\(\)\.\*\+\?\|<>\-\&\Ç\%\=\~\{\}\¿\¡\"\@\:\;\-\"\·\|\º\ª\¨\'\·\̣\─\ç\`\´\¨\^])/g, '');
+            i = 0;
+            while (i < name.length) {
+                if (!isNaN(parseFloat(name[i]))) {
+                    name = name.substring(1, name.length);
+                } else {
+                    break;
+                }
+            }
+            for (var j in Blockly.Arduino.RESERVED_WORDS_) {
+                var reserved_words = Blockly.Arduino.RESERVED_WORDS_.split(',');
+                if (name === reserved_words[j]) {
+                    this.setWarningText(RoboBlocks.locales.getKey('LANG_RESERVED_WORDS'));
+                    name = '';
+                    break;
+                } else {
+                    this.setWarningText(null);
+                }
+            }
+        }
+        return name;
+    },
+    onchange: function() {
+        if (this.last_variable !== this.getFieldValue('VAR')) {
+            var name = this.getFieldValue('VAR');
+            name = this.validName(name);
+            try {
+                this.setFieldValue(name, 'VAR');
+            } catch (e) {}
+            this.last_variable = name;
+        }
+    }
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -58,6 +58,7 @@ RoboBlocks.URL_VAR= 'http://diwo.bq.com/programando-con-variables-en-bitbloq/';
 RoboBlocks.URL_PROC_NO_RET='http://diwo.bq.com/programando-con-funciones-en-bitbloq/';
 RoboBlocks.URL_PROC='http://diwo.bq.com/programando-con-funciones-en-bitbloq-2/';
 RoboBlocks.URL_PIN_FUNC='http://diwo.bq.com/programando-los-bloques-funciones-pin';
+RoboBlocks.URL_INTERRUPTS='https://drive.google.com/open?id=0B8SXZjdcc9F9ZjBVTDRtOV8wd2s';
 
 // RGB block colors
 RoboBlocks.LANG_COLOUR_BQ = '#D04141';
@@ -72,6 +73,7 @@ RoboBlocks.LANG_COLOUR_COMMUNICATION = '#4263CE';
 RoboBlocks.LANG_COLOUR_ADVANCED = '#9142CE';
 RoboBlocks.LANG_COLOUR_VARIABLES = '#B244CC';
 RoboBlocks.LANG_COLOUR_PROCEDURES = '#CE42B3';
+RoboBlocks.LANG_COLOUR_INTERRUPTS = '#8A603E';
 RoboBlocks.setColors = function(colorArray) {
     RoboBlocks.LANG_COLOUR_BQ = colorArray[0];
     RoboBlocks.LANG_COLOUR_ZUM = colorArray[1];
@@ -85,4 +87,5 @@ RoboBlocks.setColors = function(colorArray) {
     RoboBlocks.LANG_COLOUR_ADVANCED = colorArray[9];
     RoboBlocks.LANG_COLOUR_VARIABLES = colorArray[10];
     RoboBlocks.LANG_COLOUR_PROCEDURES = colorArray[11];
+    RoboBlocks.LANG_COLOUR_INTERRUPTS = colorArray[12];
 };

--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,7 @@
                 RoboBlocks.LANG_COLOUR_ZUM,
                 RoboBlocks.LANG_COLOUR_BQ,
                 RoboBlocks.LANG_COLOUR_ADVANCED,
+                RoboBlocks.LANG_COLOUR_INTERRUPTS,
                 RoboBlocks.LANG_COLOUR_LCD,
                 RoboBlocks.LANG_COLOUR_SERVO,
             ];


### PR DESCRIPTION
These modifications are related to the design of four new blocks used to control basic interrupt system on Arduino. These four blocks do the following tasks:
-Create global volatile variables whose values can be changed on a interrupt service routine or ISR (a procedure with no arguments and no return value).
-Enable or disable interrupts (related to interrupts() and noInterrupts() of Arduino official libraries).
-Attach an ISR with a interrupt pin and a mode (related to attachInterrupt() function of Arduino official libraries).
-Detach an ISR previously defined with Attach (related to detachInterrupt() function of Arduino official libraries).

Thanks!